### PR TITLE
Change MCP to Model Context Protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LiveKit Agent with MCP Tools
 
-A voice assistant application built using the LiveKit Agents framework, capable of using Multimodal Control Protocol (MCP) tools to interact with external services.
+A voice assistant application built using the LiveKit Agents framework, capable of using [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) tools to interact with external services.
 
 ## Features
 


### PR DESCRIPTION
As far as I can tell, "Multimodal Control Protocol" was just a mistake.